### PR TITLE
 Usability improvements to service script

### DIFF
--- a/src/systemd-zram.sh
+++ b/src/systemd-zram.sh
@@ -14,7 +14,7 @@ AUTHOR='Manuel Domínguez López'  # See AUTHORS file
 MAIL='mdomlop@gmail.com'
 LICENSE='GPLv3+'  # Read LICENSE file.
 
-FRACTION=50
+FRACTION=75
 COMP_ALGORITHM='lzo'
 
 #MEMORY=`perl -ne'/^MemTotal:\s+(\d+)/ && print $1*1024;' < /proc/meminfo`

--- a/src/systemd-zram.sh
+++ b/src/systemd-zram.sh
@@ -14,20 +14,28 @@ AUTHOR='Manuel Domínguez López'  # See AUTHORS file
 MAIL='mdomlop@gmail.com'
 LICENSE='GPLv3+'  # Read LICENSE file.
 
-FRACTION=75
+FRACTION=50
+COMP_ALGORITHM='lzo'
 
 #MEMORY=`perl -ne'/^MemTotal:\s+(\d+)/ && print $1*1024;' < /proc/meminfo`
-MEMORY=`grep ^MemTotal: /proc/meminfo | awk '{print $2 * 1024}'`
+MEMORY=`grep ^MemTotal: /proc/meminfo | awk '{print $2}'`
 CPUS=`nproc`
 SIZE=$(( MEMORY * FRACTION / 100 / CPUS ))
 
 case "$1" in
   "start")
-    param=`modinfo zram|grep num_devices|cut -f2 -d:|tr -d ' '`
-    modprobe zram $param=$CPUS
+    modprobe zram num_devices=$CPUS
+
+    # Check compression algorithm support
+    if [ `grep -c "$COMP_ALGORITHM" /sys/block/zram0/comp_algorithm` -eq 0 ]; then
+        echo 'warning: unsupported compression algorithm used, falling back to lzo'
+        COMP_ALGORITHM='lzo'
+    fi;
+
     for n in `seq $CPUS`; do
       i=$((n - 1))
-      echo $SIZE > /sys/block/zram$i/disksize
+      echo $COMP_ALGORITHM > /sys/block/zram$i/comp_algorithm
+      echo ${SIZE}K > /sys/block/zram$i/disksize
       mkswap /dev/zram$i
       swapon /dev/zram$i -p 10
     done

--- a/src/systemd-zram.sh
+++ b/src/systemd-zram.sh
@@ -30,7 +30,7 @@ case "$1" in
     if [ `grep -c "$COMP_ALGORITHM" /sys/block/zram0/comp_algorithm` -eq 0 ]; then
         echo 'warning: unsupported compression algorithm used, falling back to lzo'
         COMP_ALGORITHM='lzo'
-    fi;
+    fi
 
     for n in `seq $CPUS`; do
       i=$((n - 1))


### PR DESCRIPTION
This pull request adds support for choosing the compression algorithm used to compress the data stored on the zram swap, using the sysfs interface documented in https://www.kernel.org/doc/Documentation/blockdev/zram.txt

It also simplifies memory size calculation, which is now passed unmodified as KiB to the sysfs parameters of zram devices. This fixed a problem on my Ubuntu 18.04 installation where $MEMORY had a value in scientific notation which was not recognized by the zram module.

Also, it removes unnecesary operations to set the number of zram devices to create.